### PR TITLE
Remove Consul-based auto-reloading

### DIFF
--- a/monitoring/controller.go
+++ b/monitoring/controller.go
@@ -113,7 +113,6 @@ func (m *MonitoringController) Start() error {
 func (m *MonitoringController) shutdown() error {
 	if err := m.consulClient.Agent().ServiceDeregister(m.consulServiceID); err != nil {
 		m.logger.Errorf("Error while deregistering service in Consul: %s", err)
-		return err
 	} else {
 		m.logger.Info("Successfully deregistered service in Consul")
 	}


### PR DESCRIPTION
The automatic configuration reloading from Consul has proved too error-prone in production.

For this reason, this PR removes this feature completely.