### PR TITLE
Allow provider app to add tokens outside of default authentication

### DIFF
--- a/auth/base.go
+++ b/auth/base.go
@@ -32,7 +32,7 @@ import (
 var InvalidCredentialsError error = errors.New("invalid credentials given")
 
 type AuthDecorator interface {
-	DecorateHandler(httprouter.Handle, string, *config.Application) httprouter.Handle
+	DecorateHandler(httprouter.Handle, string, *config.Application, *config.Configuration) httprouter.Handle
 	RegisterRoutes(*httprouter.Router) error
 	RegisterRequestListener(AuthRequestListener)
 }

--- a/auth/reader.go
+++ b/auth/reader.go
@@ -52,7 +52,17 @@ func (b *BearerTokenReader) tokenStringFromRequest(req *http.Request) (string, e
 		return cookie.Value, nil
 	}
 
+	cookie, err = req.Cookie("access_token")
+	if err == nil {
+		return cookie.Value, nil
+	}
+
 	jwtHeader := req.Header.Get("X-JWT")
+	if jwtHeader != "" {
+		return jwtHeader, nil
+	}
+
+	jwtHeader = req.Header.Get("x-access-token")
 	if jwtHeader != "" {
 		return jwtHeader, nil
 	}

--- a/config/auth.go
+++ b/config/auth.go
@@ -11,6 +11,7 @@ type ProviderAuthConfig struct {
 	PreAuthenticationHook string                 `json:"hook_pre_authentication"`
 	AllowAuthentication   bool                   `json:"allow_authentication"`
 	AuthenticationUri     string                 `json:"authentication_uri"`
+	Service     		  string                 `json:"service"`
 }
 
 type ApplicationAuth struct {

--- a/config/auth.go
+++ b/config/auth.go
@@ -11,7 +11,7 @@ type ProviderAuthConfig struct {
 	PreAuthenticationHook string                 `json:"hook_pre_authentication"`
 	AllowAuthentication   bool                   `json:"allow_authentication"`
 	AuthenticationUri     string                 `json:"authentication_uri"`
-	Service     		  string                 `json:"service"`
+	Service               string                 `json:"service"`
 }
 
 type ApplicationAuth struct {

--- a/dispatcher/behaviours.go
+++ b/dispatcher/behaviours.go
@@ -43,7 +43,7 @@ func NewCachingBehaviour(c cache.CacheMiddleware) DispatcherBehaviour {
 	return &cachingBehaviour{c}
 }
 
-func (c *cachingBehaviour) Apply(safe httprouter.Handle, unsafe httprouter.Handle, d Dispatcher, _ string, app *config.Application) (httprouter.Handle, httprouter.Handle, error) {
+func (c *cachingBehaviour) Apply(safe httprouter.Handle, unsafe httprouter.Handle, d Dispatcher, _ string, app *config.Application, config *config.Configuration) (httprouter.Handle, httprouter.Handle, error) {
 	if app.Caching.Enabled {
 		safe = c.cache.DecorateHandler(safe)
 
@@ -58,10 +58,10 @@ func NewAuthenticationBehaviour(a auth.AuthDecorator) DispatcherBehaviour {
 	return &authBehaviour{a}
 }
 
-func (a *authBehaviour) Apply(safe httprouter.Handle, unsafe httprouter.Handle, d Dispatcher, appName string, app *config.Application) (httprouter.Handle, httprouter.Handle, error) {
+func (a *authBehaviour) Apply(safe httprouter.Handle, unsafe httprouter.Handle, d Dispatcher, appName string, app *config.Application, config *config.Configuration) (httprouter.Handle, httprouter.Handle, error) {
 	if !app.Auth.Disable {
-		safe = a.auth.DecorateHandler(safe, appName, app)
-		unsafe = a.auth.DecorateHandler(unsafe, appName, app)
+		safe = a.auth.DecorateHandler(safe, appName, app, config)
+		unsafe = a.auth.DecorateHandler(unsafe, appName, app, config)
 	}
 	return safe, unsafe, nil
 }
@@ -74,7 +74,7 @@ func NewRatelimitBehaviour(rlim ratelimit.RateLimitingMiddleware) DispatcherBeha
 	return &ratelimitBehaviour{rlim}
 }
 
-func (r *ratelimitBehaviour) Apply(safe httprouter.Handle, unsafe httprouter.Handle, d Dispatcher, _ string, app *config.Application) (httprouter.Handle, httprouter.Handle, error) {
+func (r *ratelimitBehaviour) Apply(safe httprouter.Handle, unsafe httprouter.Handle, d Dispatcher, _ string, app *config.Application, config *config.Configuration) (httprouter.Handle, httprouter.Handle, error) {
 	if app.RateLimiting {
 		safe = r.rlim.DecorateHandler(safe)
 		unsafe = r.rlim.DecorateHandler(unsafe)

--- a/dispatcher/interface.go
+++ b/dispatcher/interface.go
@@ -29,13 +29,13 @@ import (
 
 type Dispatcher interface {
 	http.Handler
-	RegisterApplication(string, config.Application) error
+	RegisterApplication(string, config.Application, *config.Configuration) error
 	Initialize() error
 	AddBehaviour(...DispatcherBehaviour)
 }
 
 type DispatcherBehaviour interface {
-	Apply(httprouter.Handle, httprouter.Handle, Dispatcher, string, *config.Application) (httprouter.Handle, httprouter.Handle, error)
+	Apply(httprouter.Handle, httprouter.Handle, Dispatcher, string, *config.Application, *config.Configuration) (httprouter.Handle, httprouter.Handle, error)
 }
 
 type RoutingBehaviour interface {

--- a/dispatcher/pathbased.go
+++ b/dispatcher/pathbased.go
@@ -131,7 +131,7 @@ func (d *pathBasedDispatcher) buildOptionsHandler(cfg *config.Application, inner
 	}
 }
 
-func (d *pathBasedDispatcher) RegisterApplication(name string, appCfg config.Application) error {
+func (d *pathBasedDispatcher) RegisterApplication(name string, appCfg config.Application, config *config.Configuration) error {
 	routes := make(map[string]httprouter.Handle)
 
 	backendUrl := appCfg.Backend.Url
@@ -192,7 +192,7 @@ func (d *pathBasedDispatcher) RegisterApplication(name string, appCfg config.App
 
 		for _, behaviour := range d.behaviours {
 			var err error
-			safeHandler, unsafeHandler, err = behaviour.Apply(safeHandler, unsafeHandler, d, name, &appCfg)
+			safeHandler, unsafeHandler, err = behaviour.Apply(safeHandler, unsafeHandler, d, name, &appCfg, config)
 			if err != nil {
 				return err
 			}

--- a/main.go
+++ b/main.go
@@ -23,12 +23,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
-	"net/http"
-	"os"
-	"os/signal"
-	"runtime/pprof"
-	"strings"
 	"github.com/braintree/manners"
 	"github.com/garyburd/redigo/redis"
 	"github.com/hashicorp/consul/api"
@@ -42,6 +36,12 @@ import (
 	"github.com/mittwald/servicegateway/proxy"
 	"github.com/mittwald/servicegateway/ratelimit"
 	"github.com/op/go-logging"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"os/signal"
+	"runtime/pprof"
+	"strings"
 )
 
 type StartupConfig struct {
@@ -197,7 +197,7 @@ func main() {
 
 		logger.Notice("everything has shut down. exiting process.")
 
-		done<- true
+		done <- true
 	}()
 
 	go func() {
@@ -217,7 +217,7 @@ func main() {
 		}
 
 		go func() {
-			<- serverShutdown
+			<-serverShutdown
 
 			logger.Noticef("received server shutdown request. stopping creating new servers")
 			shutdownServers()

--- a/main.go
+++ b/main.go
@@ -352,14 +352,14 @@ func buildDispatcher(
 
 	for name, appCfg := range appCfgs {
 		logger.Infof("registering application '%s' from Consul", name)
-		if err := disp.RegisterApplication(name, appCfg); err != nil {
+		if err := disp.RegisterApplication(name, appCfg, cfg); err != nil {
 			return nil, nil, err
 		}
 	}
 
 	for name, appCfg := range localCfg.Applications {
 		logger.Infof("registering application '%s' from local config", name)
-		if err := disp.RegisterApplication(name, appCfg); err != nil {
+		if err := disp.RegisterApplication(name, appCfg, cfg); err != nil {
 			return nil, nil, err
 		}
 	}


### PR DESCRIPTION
This pull request allows users to specify a provider service. Once a service is set this Service can send additional headers to store tokens on routes which are not the default authentication route. This is useful if you want to implement an OAuth2 Flow for example.

The following headers can be used: X-Gateway-BodyToken, X-Gateway-HeaderToken, X-Gateway-CookieToken. Each header can store a key which in turn points to a JWT. This JWT will be then replaced with a token.
