### PR TITLE
rewrite content length

### DIFF
--- a/auth/rest.go
+++ b/auth/rest.go
@@ -293,7 +293,11 @@ func rewriteBodyAccessTokens(resp *httptest.ResponseRecorder, req *http.Request,
 		if err != nil {
 			return err
 		}
-		resp.Write(jsonResponse)
+		contentLength, err := resp.Write(jsonResponse)
+		if err != nil {
+			return err
+		}
+		resp.Header().Set("Content-Length", fmt.Sprintf("%d", contentLength))
 	}
 
 	return nil


### PR DESCRIPTION
If I am right, in https://golang.org/src/net/http/httptest/recorder.go line 185, the content length of the original request is used on default 🙈 