### PR TITLE
add option to disable ingress in helm chart

### DIFF
--- a/deploy/helm-chart/servicegateway/templates/ingress.yaml
+++ b/deploy/helm-chart/servicegateway/templates/ingress.yaml
@@ -44,7 +44,7 @@ spec:
 ---
 {{- $fullName := include "servicegateway.fullname" . -}}
 {{- range $ingressName, $ingress := .Values.ingresses }}
-{{- if $ingress }}
+{{- if and $ingress (or $ingress.enabled (eq ($ingress.enabled | toString) "<nil>")) }}
 apiVersion: {{ template "servicegateway.ingress.apiVersion" $ }}
 kind: Ingress
 metadata:

--- a/deploy/helm-chart/servicegateway/values.yaml
+++ b/deploy/helm-chart/servicegateway/values.yaml
@@ -50,6 +50,7 @@ ingress:
 ingresses: {}
 #ingresses:
 #  youringressname:
+#    enabled: true
 #    annotations:
 #      kubernetes.io/ingress.class: nginx
 #      kubernetes.io/tls-acme: "true"


### PR DESCRIPTION
This option is needed to override/disable an ingress specified in a parent values.yaml
Ingress is enabled by default.